### PR TITLE
fix "input.realpower.nominal" for ePDU

### DIFF
--- a/src/mapping.conf
+++ b/src/mapping.conf
@@ -180,7 +180,8 @@
         "ups.realpower.nominal" :       "max_power",
         "ups.power.nominal"     :       "power.default.nominal",
         // same for ePDU
-        "input.realpower.nominal":      "power.default.nominal",
+        "input.power.nominal"   :       "power.default.nominal",
+        "input.realpower.nominal":      "realpower.default.nominal", //ePDU/Marlin
         "ups.firmware"          :       "firmware",
         "ups.firmware.aux"      :       "firmware.aux",
 

--- a/src/mapping.conf
+++ b/src/mapping.conf
@@ -180,7 +180,7 @@
         "ups.realpower.nominal" :       "max_power",
         "ups.power.nominal"     :       "power.default.nominal",
         // same for ePDU
-        "input.power.nominal"   :       "power.default.nominal",
+        "input.realpower.nominal":      "power.default.nominal",
         "ups.firmware"          :       "firmware",
         "ups.firmware.aux"      :       "firmware.aux",
 


### PR DESCRIPTION
see https://github.com/42ity/nut/blob/FTY/drivers/eaton-pdu-marlin-mib.c#L644