### PR TITLE
Add missing mapping for battery.status.code

### DIFF
--- a/resources/mapping.conf
+++ b/resources/mapping.conf
@@ -77,6 +77,7 @@
         "battery.voltage.cell.max" :   "voltage.battery.cell.max",
         "battery.capacity.nominal"  :   "capacity.battery.nominal",
         "battery.status"            :   "status.battery",
+        "battery.status.code"       :   "status.battery.code",
         "battery.charger.status"    :   "status.battery.charger",
         "battery.temperature"       :   "temperature.battery",
         "battery.temperature.cell.min" :   "temperature.battery.cell.min",


### PR DESCRIPTION
Signed-off-by: Arnaud Quette <ArnaudQuette@eaton.com>