### PR TITLE
add 'driver.name' and move 'battery.packs.external' from 'PhysicsMapp…

### DIFF
--- a/resources/mapping.conf
+++ b/resources/mapping.conf
@@ -82,7 +82,6 @@
         "battery.temperature"       :   "temperature.battery",
         "battery.temperature.cell.min" :   "temperature.battery.cell.min",
         "battery.temperature.cell.max" :   "temperature.battery.cell.max",
-        "battery.packs.external"       :   "battery.packs.external",
 
         "outlet.#.current"      :   "current.outlet.#",
         "outlet.#.voltage"      :   "voltage.outlet.#",
@@ -130,6 +129,7 @@
         "ups.mfr"               :       "manufacturer",
         "device.serial"         :       "serial_no",
         "device.type"           :       "device.type",
+        "driver.name"           :       "driver.name",
         "type"                  :       "device.type",
         "device.description"    :       "device.description",
         "device.contact"        :       "device.contact",
@@ -167,6 +167,8 @@
 
         "outlet.#.status"        :      "status.outlet.#",
         "outlet.#.current.status":      "status.outlet.#.current",
+
+
 
         "input.phases"          :       "phases.input",
 
@@ -206,6 +208,8 @@
         "battery.charge.low"    :       "charge.battery.low",
         "battery.runtime.low"   :       "runtime.battery.low",
         "battery.charge.restart":       "charge.battery.restart",
+        "battery.packs.external":       "battery.packs.external",
+
 
 
         /*config ePDU*/


### PR DESCRIPTION
…ing' to 'InventoryMapping'

battery.packs.external didn't appear in fty-nut properties when it was in PhysicsMapping section